### PR TITLE
 Translate 2.1  Use Async-Await or promises for async error handling

### DIFF
--- a/README.italian.md
+++ b/README.italian.md
@@ -120,7 +120,7 @@ Anche se questo è un modello di sviluppo molto comune, gli sviluppatori di API 
 
 ## ![✔] 2.1 Usa Async-Await o le promises per la gestione degli errori asincroni
 
-**TL;DR:** Gestire gli errori asincroni in stile callback è probabilmente la via più veloce per l'inferno (a.k.a la piramide del destino). Il miglior regalo che tu possa fare al tuo codice è, invece, usare una rinomata libreria di promises o di async-await che permetta una sintassi del codice più compatta e familiare come il try-catch. 
+**TL;DR:** Gestire gli errori asincroni in stile callback è probabilmente la via più veloce per l'inferno (a.k.a la piramide della sventura). Il miglior regalo che tu possa fare al tuo codice è, invece, usare una rinomata libreria di promises o di async-await che permetta una sintassi del codice più compatta e familiare come il try-catch. 
 
 **Altrimenti:** Lo stile di callback di Node.js, function(err, response), è un promettente modo per rendere il codice non manutenibile a causa del mix di gestione degli errori con codice casuale, nidificazione eccessiva e pattern di codifica scomodi
 

--- a/README.italian.md
+++ b/README.italian.md
@@ -118,13 +118,13 @@ Anche se questo è un modello di sviluppo molto comune, gli sviluppatori di API 
 
 # `2. Pratiche Di Gestione Degli Errori`
 
-## ![✔] 2.1 Use Async-Await or promises for async error handling
+## ![✔] 2.1 Usa Async-Await o promises per la gestione degli errori asincroni
 
-**TL;DR:** Handling async errors in callback style is probably the fastest way to hell (a.k.a the pyramid of doom). The best gift you can give to your code is using a reputable promise library or async-await instead which enables a much more compact and familiar code syntax like try-catch
+**TL;DR:** Gestire gli errori asincroni in stile callback è probabilmente la via più veloce per l'inferno (a.k.a la piramide del destino). Il miglior regalo che tu possa fare al tuo codice è, invece, usare una rinomata libreria di promises o di async-await che permetta una sintassi del codice più compatta e familiare come il try-catch. 
 
-**Otherwise:** Node.js callback style, function(err, response), is a promising way to un-maintainable code due to the mix of error handling with casual code, excessive nesting, and awkward coding patterns
+**Otherwise:** Lo stile di callback di Node.js, function(err, response), è un promettente modo per rendere il codice non manutenibile a causa del mix di gestione degli errori con codice casuale, nidificazione eccessiva e pattern di codifica scomodi
 
-🔗 [**Read More: avoiding callbacks**](/sections/errorhandling/asyncerrorhandling.md)
+🔗 [**Leggi di più: evita callbacks**](/sections/errorhandling/asyncerrorhandling.italian.md)
 
 <br/><br/>
 

--- a/README.italian.md
+++ b/README.italian.md
@@ -118,11 +118,11 @@ Anche se questo è un modello di sviluppo molto comune, gli sviluppatori di API 
 
 # `2. Pratiche Di Gestione Degli Errori`
 
-## ![✔] 2.1 Usa Async-Await o promises per la gestione degli errori asincroni
+## ![✔] 2.1 Usa Async-Await o le promises per la gestione degli errori asincroni
 
 **TL;DR:** Gestire gli errori asincroni in stile callback è probabilmente la via più veloce per l'inferno (a.k.a la piramide del destino). Il miglior regalo che tu possa fare al tuo codice è, invece, usare una rinomata libreria di promises o di async-await che permetta una sintassi del codice più compatta e familiare come il try-catch. 
 
-**Otherwise:** Lo stile di callback di Node.js, function(err, response), è un promettente modo per rendere il codice non manutenibile a causa del mix di gestione degli errori con codice casuale, nidificazione eccessiva e pattern di codifica scomodi
+**Altrimenti:** Lo stile di callback di Node.js, function(err, response), è un promettente modo per rendere il codice non manutenibile a causa del mix di gestione degli errori con codice casuale, nidificazione eccessiva e pattern di codifica scomodi
 
 🔗 [**Leggi di più: evita callbacks**](/sections/errorhandling/asyncerrorhandling.italian.md)
 

--- a/sections/errorhandling/asyncerrorhandling.italian.md
+++ b/sections/errorhandling/asyncerrorhandling.italian.md
@@ -1,0 +1,63 @@
+# Usa Async-Await o promises per la gestione degli errori asincroni
+
+### Spiegazione in un paragrafo
+Le callback non scalano correttamente poiché la maggior parte dei programmatori non le conosce. Costringono a controllare gli errori dappertutto, a gestire il pessimo codice e rendono difficile ragionare sul flusso di esecuzione.
+Librerie di Promise come BlueBird, async e Q 
+Promise libraries like BlueBird, async, and Q impacchettano uno stile di codice standard usando RETURN e THROW per controllare il flusso del programma. Più nello specifico, loro supportano lo stile preferito di gestione degli errori tramite try-catch  che consente di liberare il percorso del codice principale dagli errori in ogni funzione
+
+### Esempio di codice - usando promises per gestire gli errori
+
+```javascript
+doWork()
+ .then(doWork)
+ .then(doOtherWork)
+ .then((result) => doWork)
+ .catch((error) => {throw error;})
+ .then(verify);
+```
+
+### Esempio di codice Anti pattern – stile di gestione degli errori con callbacks
+
+```javascript
+getData(someParameter, function(err, result) {
+    if(err !== null) {
+        // do something like calling the given callback function and pass the error
+        getMoreData(a, function(err, result) {
+            if(err !== null) {
+                // do something like calling the given callback function and pass the error
+                getMoreData(b, function(c) {
+                    getMoreData(d, function(e) {
+                        if(err !== null ) {
+                            // you get the idea? 
+                        }
+                    })
+                });
+            }
+        });
+    }
+});
+```
+
+### Nota da un Blog: "Abbiamo un problema con promises"
+
+ Dal blog pouchdb.com
+
+ > ……E in effetti, le callback fanno qualcosa di ancora più sinistro: ci privano dello stack, cosa che di solito diamo per scontato nei linguaggi di programmazione. Scrivere codice senza uno stack è un po' come guidare una macchina senza il pedale del freno: non ti rendi conto di quanto ne hai bisogno finché quando ne hai bisogno non è lì. Il punto centrale di promises è di restituirci i fondamenti linguistici che abbiamo perso quando siamo andati in asincrono: return, throw e stack. Ma devi sapere come usare le promises correttamente per trarne vantaggio.
+
+### Nota da un Blog: "Il metodo promises è molto più compatto"
+
+ Dal blog gosquared.com
+
+ > ………Il metodo promesse è molto più compatto, più chiaro e veloce da scrivere. Se si verifica un errore o un'eccezione all'interno di una delle operazioni, viene gestito dal singolo gestore di .catch(). Avere questo unico posto per gestire tutti gli errori significa che non è necessario scrivere il controllo degli errori per ogni fase del lavoro.
+
+### Nota da un Blog: "Le Promises sono native in ES6, possono essere usate con generatori"
+
+ Dal blog StrongLoop
+
+ > …Le callback hanno una pessima storia di gestione degli errori. Le Promises sono meglio. Adotta la gestione degli errori incorporata in Express con promises e riduci significativamente le possibilità di un'eccezione non rilevata. Le promises sono native in ES6, possono essere utilizzate con generatori e proposte ES7 come async/await attraverso compilatori come Babel
+
+### Nota da un Blog: "Tutti quei costrutti di controllo del flusso regolari a cui sei abituato sono completamente danneggiati"
+
+ Dal blog Benno’s
+
+ > ……Una delle cose migliori della programmazione asincrona basata sulle callback è che fondamentalmente tutti quei costrutti di controllo del flusso regolari a cui siete abituati sono completamente rotti. Tuttavia, quello che trovo più rotto è la gestione delle eccezioni. Javascript fornisce una prova abbastanza familiare... costruisci il costrutto per gestire le eccezioni. Il problema con le eccezioni è che forniscono un ottimo modo di correggere gli errori su uno stack di chiamate, ma finiscono per essere completamente inutili se l'errore si verifica su uno stack diverso...

--- a/sections/errorhandling/asyncerrorhandling.italian.md
+++ b/sections/errorhandling/asyncerrorhandling.italian.md
@@ -47,7 +47,7 @@ getData(someParameter, function(err, result) {
 
  Dal blog gosquared.com
 
- > ………Il metodo promesse è molto più compatto, più chiaro e veloce da scrivere. Se si verifica un errore o un'eccezione all'interno di una delle operazioni, viene gestito dal singolo gestore di .catch(). Avere questo unico posto per gestire tutti gli errori significa che non è necessario scrivere il controllo degli errori per ogni fase del lavoro.
+ > ………Il metodo delle promises è molto più compatto, più chiaro e veloce da scrivere. Se si verifica un errore o un'eccezione all'interno di una delle operazioni, viene gestito dal singolo gestore di .catch(). Avere questo unico posto per gestire tutti gli errori significa che non è necessario scrivere il controllo degli errori per ogni fase del lavoro.
 
 ### Nota da un Blog: "Le Promises sono native in ES6, possono essere usate con generatori"
 

--- a/sections/errorhandling/asyncerrorhandling.italian.md
+++ b/sections/errorhandling/asyncerrorhandling.italian.md
@@ -1,9 +1,8 @@
-# Usa Async-Await o promises per la gestione degli errori asincroni
+# Usa Async-Await o le promises per la gestione degli errori asincroni
 
 ### Spiegazione in un paragrafo
 Le callback non scalano correttamente poiché la maggior parte dei programmatori non le conosce. Costringono a controllare gli errori dappertutto, a gestire il pessimo codice e rendono difficile ragionare sul flusso di esecuzione.
-Librerie di Promise come BlueBird, async e Q 
-Promise libraries like BlueBird, async, and Q impacchettano uno stile di codice standard usando RETURN e THROW per controllare il flusso del programma. Più nello specifico, loro supportano lo stile preferito di gestione degli errori tramite try-catch  che consente di liberare il percorso del codice principale dagli errori in ogni funzione
+Librerie di Promise come BlueBird, async e Q impacchettano uno stile di codice standard usando RETURN e THROW per controllare il flusso del programma. Più nello specifico, loro supportano lo stile preferito di gestione degli errori tramite try-catch  che consente di liberare il flusso del codice principale dagli errori in ogni funzione
 
 ### Esempio di codice - usando promises per gestire gli errori
 


### PR DESCRIPTION
Complete translation of 2.1 close #7  

**List any particular doubts for feedback**
I didn't translate `promises` as `promesse` because i think it's better to maintain the international name  for future personal research  which users ought to do
**Check the translation is complete**
- [x] Translate **TL;DR** on `README.italian.md`

- [x] Has **Read more**
	- [x] Create `section/errorhandling/asyncerrorhandling.italian.md` and update links on `README.italian.md`
	- [x] Translate **Read more**

